### PR TITLE
Refinements to library from real use

### DIFF
--- a/packtype/__main__.py
+++ b/packtype/__main__.py
@@ -81,7 +81,7 @@ def main(render: list[str], debug: bool, only: list[str], spec: str, outdir: str
     # Filter out just those that were selected
     if only:
         only = {str(x).lower() for x in only}
-        pkgs = [x for x in pkgs if type(x).__name__.lower() in only]
+        pkgs = [x for x in pkgs if x.__name__.lower() in only]
     # Create output directory if it doesn't already exist
     outdir.mkdir(parents=True, exist_ok=True)
     # Render
@@ -105,8 +105,9 @@ def main(render: list[str], debug: bool, only: list[str], spec: str, outdir: str
         "Union": Union,
     }
     # Iterate packages to render
-    for pkg in pkgs:
-        pkg_name = type(pkg).__name__
+    for pkg_cls in pkgs:
+        pkg_name = pkg_cls.__name__
+        pkg = pkg_cls()
         # Iterate outputs to render
         for lang in render:
             tmpl_name, suffix = tmpl_list[lang]

--- a/packtype/array.py
+++ b/packtype/array.py
@@ -24,6 +24,9 @@ class ArraySpec:
     def _pt_references(self) -> Iterable[Any]:
         return self.base._pt_references()
 
+    def __call__(self, **kwds) -> "Array":
+        return Array(self, **kwds)
+
 
 class Array:
     def __init__(self, spec: ArraySpec, *args, **kwds):
@@ -40,3 +43,7 @@ class Array:
 
     def __len__(self) -> int:
         return len(self._pt_entries)
+
+    @property
+    def _pt_width(self) -> int:
+        return sum(x._pt_width for x in self._pt_entries)

--- a/packtype/assembly.py
+++ b/packtype/assembly.py
@@ -35,7 +35,7 @@ class Assembly(Base):
     def __init__(self, parent: Base | None = None) -> None:
         super().__init__(parent)
         self._pt_fields = {}
-        for fname, ftype, fval in self._pt_definitions:
+        for fname, ftype, fval in self._pt_definitions():
             if isinstance(ftype, ArraySpec):
                 if isinstance(ftype.base, Primitive):
                     finst = Array(ftype, parent=self, default=fval)

--- a/packtype/assembly.py
+++ b/packtype/assembly.py
@@ -31,20 +31,25 @@ class WidthError(Exception):
     pass
 
 
+class AssignmentError(Exception):
+    pass
+
+
 class Assembly(Base):
-    def __init__(self, parent: Base | None = None) -> None:
-        super().__init__(parent)
+    def __init__(self) -> None:
+        super().__init__()
         self._pt_fields = {}
         for fname, ftype, fval in self._pt_definitions():
             if isinstance(ftype, ArraySpec):
                 if isinstance(ftype.base, Primitive):
-                    finst = Array(ftype, parent=self, default=fval)
+                    finst = Array(ftype, default=fval)
                 else:
-                    finst = Array(ftype, parent=self)
+                    finst = Array(ftype)
             elif issubclass(ftype, Primitive):
-                finst = ftype(parent=self, default=fval)
+                finst = ftype(default=fval)
             else:
-                finst = ftype(parent=self)
+                finst = ftype()
+            finst._PT_PARENT = self
             setattr(self, fname, finst)
             self._pt_fields[finst] = fname
 
@@ -67,78 +72,112 @@ class PackedAssembly(Assembly):
         "packing": (Packing.FROM_LSB, [Packing.FROM_LSB, Packing.FROM_MSB]),
         "width": (-1, lambda x: int(x) > 0),
     }
+    _PT_PACKING: Packing
+    _PT_WIDTH: int
+    _PT_RANGES: dict
+    _PT_PADDING: int
 
-    def __init__(self, parent: Base | None = None) -> None:
-        super().__init__(parent)
-        self._pt_packing = self._PT_ATTRIBUTES["packing"]
-        self._pt_width = int(self._PT_ATTRIBUTES["width"])
-        self._pt_ranges = {}
+    def __init__(self, **kwds) -> None:
+        super().__init__()
+        # Create padding field
+        if self._PT_PADDING > 0:
+            padding = Scalar[self._PT_PADDING]()
+            self._pt_fields[padding] = "_padding"
+            setattr(self, "_padding", padding)
+        # Assign field values
+        for key, value in kwds.items():
+            field = getattr(self, key, None)
+            if field is None:
+                raise AssignmentError(
+                    f"{type(self).__name__} does not contain a field called "
+                    f"'{key}'"
+                )
+            if isinstance(field, Array):
+                if not isinstance(value, list) or len(value) != len(field):
+                    raise AssignmentError(
+                        f"Cannot assign value to field {key} as it is an array "
+                        f"of {len(field)} entries and the assigned value does "
+                        f"not have the same dimensions"
+                    )
+                for idx, aval in enumerate(value):
+                    field[idx]._pt_set(aval)
+            else:
+                field._pt_set(value)
+
+    @classmethod
+    def _pt_construct(cls, parent: Base, packing: Packing, width: int):
+        cls._PT_PACKING = packing
+        cls._PT_WIDTH = int(width)
+        cls._PT_RANGES = {}
         # Check for oversized fields
-        if self._pt_width < 0:
-            self._pt_width = self._pt_field_width
-        elif self._pt_width < self._pt_field_width:
+        if cls._PT_WIDTH < 0:
+            cls._PT_WIDTH = cls._pt_field_width()
+        elif cls._PT_WIDTH < cls._pt_field_width():
             raise WidthError(
-                f"Fields of {type(self).__name__} total {self._pt_field_width} "
+                f"Fields of {cls.__name__} total {cls._pt_field_width()} "
                 f"bits which does not fit within the specified width of "
-                f"{self._pt_width} bits"
+                f"{cls._PT_WIDTH} bits"
             )
         # Place fields LSB -> MSB
-        if self._pt_packing is Packing.FROM_LSB:
+        if cls._PT_PACKING is Packing.FROM_LSB:
             lsb = 0
-            for finst, fname in self._pt_fields.items():
-                if isinstance(finst, Array):
-                    for idx, entry in enumerate(finst):
-                        self._pt_ranges[fname, idx] = (lsb, lsb + entry._pt_width - 1)
-                        lsb += entry._pt_width
+            for fname, ftype, _ in cls._pt_definitions():
+                if isinstance(ftype, ArraySpec):
+                    fwidth = ftype.base()._pt_width
+                    for idx in range(ftype.dimension):
+                        cls._PT_RANGES[fname, idx] = (lsb, lsb + fwidth - 1)
+                        lsb += fwidth
                 else:
-                    self._pt_ranges[fname] = (lsb, lsb + finst._pt_width - 1)
-                    lsb += finst._pt_width
+                    fwidth = ftype()._pt_width
+                    cls._PT_RANGES[fname] = (lsb, lsb + fwidth - 1)
+                    lsb += fwidth
             # Insert padding
-            if lsb < self._pt_width:
-                padding = Scalar[self._pt_width - lsb]()
-                self._pt_fields[padding] = "_padding"
-                self._pt_ranges["_padding"] = (lsb, self._pt_width - 1)
+            cls._PT_PADDING = max(0, cls._PT_WIDTH - lsb)
+            if cls._PT_PADDING > 0:
+                cls._PT_RANGES["_padding"] = (lsb, cls._PT_WIDTH - 1)
         # Place fields MSB -> LSB
         else:
-            msb = self._pt_width - 1
-            for finst, fname in self._pt_fields.items():
-                if isinstance(finst, Array):
-                    for idx, entry in enumerate(finst):
-                        self._pt_ranges[fname, idx] = (msb - entry._pt_width + 1, msb)
-                        msb -= entry._pt_width
+            msb = cls._PT_WIDTH - 1
+            for fname, ftype, _ in cls._pt_definitions():
+                if isinstance(ftype, ArraySpec):
+                    fwidth = ftype.base()._pt_width
+                    for idx in range(ftype.dimension):
+                        cls._PT_RANGES[fname, idx] = (msb - fwidth + 1, msb)
+                        msb -= fwidth
                 else:
-                    self._pt_ranges[fname] = (msb - finst._pt_width + 1, msb)
-                    msb -= finst._pt_width
+                    fwidth = ftype()._pt_width
+                    cls._PT_RANGES[fname] = (msb - fwidth + 1, msb)
+                    msb -= fwidth
             # Insert padding
-            if msb >= 0:
-                padding = Scalar[msb + 1]()
-                self._pt_fields[padding] = "_padding"
-                self._pt_ranges["_padding"] = (0, msb)
+            cls._PT_PADDING = max(0, msb + 1)
+            if cls._PT_PADDING > 0:
+                cls._PT_RANGES["_padding"] = (0, msb)
 
-    @property
+    @classmethod
     @functools.cache  # noqa: B019
-    def _pt_field_width(self) -> None:
+    def _pt_field_width(cls) -> int:
         total_width = 0
-        for field in self._pt_fields.keys():
-            if isinstance(field, Array):
-                total_width += sum(x._pt_width for x in field)
-            else:
-                total_width += field._pt_width
+        for fname, ftype, _ in cls._pt_definitions():
+            total_width += ftype()._pt_width
         return total_width
 
     @property
-    def _pt_mask(self) -> None:
-        return (1 << self._pt_width) - 1
+    def _pt_width(self) -> int:
+        return self._PT_WIDTH
+
+    @property
+    def _pt_mask(self) -> int:
+        return (1 << self._PT_WIDTH) - 1
 
     @property
     def _pt_fields_lsb_asc(self) -> list[Base]:
         pairs = []
         for finst, fname in self._pt_fields.items():
             if isinstance(finst, Array):
-                lsb = min(self._pt_ranges[(fname, x)][0] for x in range(len(finst)))
-                msb = max(self._pt_ranges[(fname, x)][1] for x in range(len(finst)))
+                lsb = min(self._PT_RANGES[(fname, x)][0] for x in range(len(finst)))
+                msb = max(self._PT_RANGES[(fname, x)][1] for x in range(len(finst)))
             else:
-                lsb, msb = self._pt_ranges[fname]
+                lsb, msb = self._PT_RANGES[fname]
             pairs.append((lsb, msb, (fname, finst)))
         return sorted(pairs, key=lambda x: x[0])
 
@@ -147,18 +186,18 @@ class PackedAssembly(Assembly):
         pairs = []
         for finst, fname in self._pt_fields.items():
             if isinstance(finst, Array):
-                lsb = min(self._pt_ranges[(fname, x)][0] for x in range(len(finst)))
-                msb = max(self._pt_ranges[(fname, x)][1] for x in range(len(finst)))
+                lsb = min(self._PT_RANGES[(fname, x)][0] for x in range(len(finst)))
+                msb = max(self._PT_RANGES[(fname, x)][1] for x in range(len(finst)))
             else:
-                lsb, msb = self._pt_ranges[fname]
+                lsb, msb = self._PT_RANGES[fname]
             pairs.append((lsb, msb, (fname, finst)))
         return sorted(pairs, key=lambda x: x[1], reverse=True)
 
     def _pt_lsb(self, field: str) -> int:
-        return self._pt_ranges[field][0]
+        return self._PT_RANGES[field][0]
 
     def _pt_msb(self, field: str) -> int:
-        return self._pt_ranges[field][1]
+        return self._PT_RANGES[field][1]
 
     def _pt_pack(self) -> int:
         packed = 0

--- a/packtype/assembly.py
+++ b/packtype/assembly.py
@@ -49,7 +49,11 @@ class Assembly(Base):
             self._pt_fields[finst] = fname
 
     def __setattr__(self, name: str, value: Any) -> None:
-        if not name.startswith("_") and hasattr(self, name) and isinstance(obj := getattr(self, name), Base):
+        if (
+            not name.startswith("_")
+            and hasattr(self, name)
+            and isinstance(obj := getattr(self, name), Base)
+        ):
             obj._pt_set(value)
         else:
             return super().__setattr__(name, value)
@@ -91,7 +95,7 @@ class PackedAssembly(Assembly):
                     lsb += finst._pt_width
             # Insert padding
             if lsb < self._pt_width:
-                padding = Scalar[self._pt_width-lsb]()
+                padding = Scalar[self._pt_width - lsb]()
                 self._pt_fields[padding] = "_padding"
                 self._pt_ranges["_padding"] = (lsb, self._pt_width - 1)
         # Place fields MSB -> LSB
@@ -107,7 +111,7 @@ class PackedAssembly(Assembly):
                     msb -= finst._pt_width
             # Insert padding
             if msb >= 0:
-                padding = Scalar[msb+1]()
+                padding = Scalar[msb + 1]()
                 self._pt_fields[padding] = "_padding"
                 self._pt_ranges["_padding"] = (0, msb)
 
@@ -183,12 +187,11 @@ class PackedAssembly(Assembly):
                 for idx, entry in enumerate(finst):
                     entry._pt_set(
                         (value >> self._pt_lsb((fname, idx))) & entry._pt_mask,
-                        force=True
+                        force=True,
                     )
             else:
                 finst._pt_set(
-                    (value >> self._pt_lsb(fname)) & finst._pt_mask,
-                    force=True
+                    (value >> self._pt_lsb(fname)) & finst._pt_mask, force=True
                 )
         if not force:
             self._pt_updated(self)

--- a/packtype/assembly.py
+++ b/packtype/assembly.py
@@ -221,6 +221,7 @@ class PackedAssembly(Assembly):
         return self._pt_pack()
 
     def _pt_set(self, value: int, force: bool = False) -> None:
+        value = int(value)
         for finst, fname in self._pt_fields.items():
             if isinstance(finst, Array):
                 for idx, entry in enumerate(finst):

--- a/packtype/base.py
+++ b/packtype/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import dataclasses
-from typing import Any, Optional
+from typing import Any, Optional, Self
 
 from .array import ArraySpec
 
@@ -37,18 +37,15 @@ class Base(metaclass=MetaBase):
     _PT_ATTRIBUTES: dict[str, tuple[Any, list[Any]]] = {}
     # The dataclass definition
     _PT_DEF = None
-    # A shared instance will be created as the imposter rather than a class, this
-    # is used for defining packages
-    _PT_SHARED: bool = False
     # Tuple of source file and line number where the type is defined
     _PT_SOURCE: tuple[str, int] = ("?", 0)
-
-    def __init__(self, parent: Optional["Base"] = None) -> None:
-        self._pt_parent = parent
+    # Handle to parent
+    _PT_PARENT: Self = None
 
     @classmethod
-    def _pt_construct(cls, **_kwds):
+    def _pt_construct(cls, parent: Self | None = None, **_kwds):
         del _kwds
+        cls._PT_PARENT = parent
 
     @classmethod
     def _pt_name(cls):
@@ -87,3 +84,7 @@ class Base(metaclass=MetaBase):
             if not isinstance(field, ArraySpec):
                 collect.add(field)
         return collect
+
+    @property
+    def _pt_parent(self) -> Self:
+        return self._PT_PARENT

--- a/packtype/base.py
+++ b/packtype/base.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 import dataclasses
-from typing import Any, Optional, Self
+from typing import Any, Optional
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self  # noqa: UP035
 
 from .array import ArraySpec
 

--- a/packtype/base.py
+++ b/packtype/base.py
@@ -47,13 +47,17 @@ class Base(metaclass=MetaBase):
         self._pt_parent = parent
 
     @classmethod
+    def _pt_construct(cls, **_kwds):
+        del _kwds
+
+    @classmethod
     def _pt_name(cls):
         return cls.__name__
 
-    @property
-    def _pt_definitions(self) -> list[str, Any]:
+    @classmethod
+    def _pt_definitions(cls) -> list[str, Any]:
         yield from (
-            (x.name, x.type, x.default) for x in dataclasses.fields(self._PT_DEF)
+            (x.name, x.type, x.default) for x in dataclasses.fields(cls._PT_DEF)
         )
 
     def _pt_updated(self, *path: "Base"):

--- a/packtype/enum.py
+++ b/packtype/enum.py
@@ -99,3 +99,25 @@ class Enum(Assembly):
             used.append(fval.value)
             # Create a lookup table
             self._pt_lookup[fval.value] = (fname, fval)
+        # Set initial value
+        self._pt_set(0)
+
+    @property
+    def _pt_mask(self) -> int:
+        return (1 << self._pt_width) - 1
+
+    @property
+    def value(self) -> int:
+        return self.__value
+
+    @value.setter
+    def value(self, value: int) -> int:
+        self._pt_set(value)
+
+    def _pt_set(self, value: int, force: bool = False) -> None:
+        _, self.__value = self._pt_lookup.get(value, (None, int(value)))
+        if not force:
+            self._pt_updated()
+
+    def __int__(self) -> int:
+        return int(self.__value)

--- a/packtype/enum.py
+++ b/packtype/enum.py
@@ -138,7 +138,7 @@ class Enum(Base):
         self._pt_set(value)
 
     def _pt_set(self, value: int, force: bool = False) -> None:
-        _, self.__value = self._PT_LKP_INST.get(value, (None, int(value)))
+        self.__value = value
         if not force:
             self._pt_updated()
 

--- a/packtype/enum.py
+++ b/packtype/enum.py
@@ -150,4 +150,4 @@ class Enum(Base):
         if value in cls._PT_LKP_VALUE:
             return cls._PT_LKP_VALUE[value]
         else:
-            return cls(cls, value)
+            return cls(value)

--- a/packtype/enum.py
+++ b/packtype/enum.py
@@ -16,7 +16,6 @@ import enum
 import math
 from typing import Any
 
-from .assembly import Assembly
 from .base import Base
 
 
@@ -30,77 +29,97 @@ class EnumError(Exception):
     pass
 
 
-class Enum(Assembly):
+class Enum(Base):
     _PT_ATTRIBUTES: dict[str, tuple[Any, list[Any]]] = {
         "mode": (EnumMode.INDEXED, list(EnumMode)),
         "width": (-1, lambda x: int(x) > 0),
         "prefix": (None, lambda x: isinstance(x, str)),
     }
 
-    def __init__(self, parent: Base | None = None) -> None:
+    _PT_MODE: EnumMode = EnumMode.INDEXED
+    _PT_WIDTH: int = 0
+    _PT_PREFIX: str | None = None
+    _PT_LOOKUP: dict = {}
+
+    def __init__(self, parent: Base | None = None, value: int = 0) -> None:
         super().__init__(parent)
-        self._pt_mode = self._PT_ATTRIBUTES["mode"]
-        self._pt_width = self._PT_ATTRIBUTES["width"]
-        self._pt_prefix = self._PT_ATTRIBUTES["prefix"]
-        if self._pt_prefix is None:
-            self._pt_prefix = self._pt_name()
-        self._pt_lookup = {}
+        # Set initial value
+        self._pt_set(value, force=True)
+
+    @classmethod
+    def _pt_construct(cls, mode: EnumMode, width: int, prefix: str | None) -> None:
+        super()._pt_construct()
+        cls._PT_MODE = mode
+        cls._PT_WIDTH = width
+        cls._PT_PREFIX = prefix
+        if cls._PT_PREFIX is None:
+            cls._PT_PREFIX = cls._pt_name()
+        cls._PT_LOOKUP = {}
+        # Assign values
+        assignments = {}
         # Indexed
-        if self._pt_mode is EnumMode.INDEXED:
+        if cls._PT_MODE is EnumMode.INDEXED:
             next_val = 0
-            for fval in self._pt_fields.keys():
-                if fval.value is None:
-                    fval.value = next_val
-                next_val = fval.value + 1
+            for fname, _, fval in cls._pt_definitions():
+                if fval is None:
+                    fval = next_val
+                next_val = fval + 1
+                assignments[fname] = fval
         # One-hot
-        elif self._pt_mode is EnumMode.ONE_HOT:
+        elif cls._PT_MODE is EnumMode.ONE_HOT:
             next_val = 1
-            for fval, fname in self._pt_fields.items():
-                if fval.value is None:
-                    fval.value = next_val
-                if (math.log2(fval.value) % 1) != 0:
+            for fname, _, fval in cls._pt_definitions():
+                if fval is None:
+                    fval = next_val
+                if (math.log2(fval) % 1) != 0:
                     raise EnumError(
-                        f"Enum entry {fname} has value {fval.value} that is not "
+                        f"Enum entry {fname} has value {fval} that is not "
                         f"one-hot"
                     )
-                next_val = fval.value << 1
+                next_val = fval << 1
+                assignments[fname] = fval
         # Gray code
-        elif self._pt_mode is EnumMode.GRAY:
-            for idx, (fval, fname) in enumerate(self._pt_fields.items()):
+        elif cls._PT_MODE is EnumMode.GRAY:
+            for idx, (fname, _, fval) in enumerate(cls._pt_definitions()):
                 gray_val = idx ^ (idx >> 1)
-                if fval.value is None:
-                    fval.value = gray_val
-                elif fval.value != gray_val:
+                if fval is None:
+                    fval = gray_val
+                elif fval != gray_val:
                     raise EnumError(
-                        f"Enum entry {fname} has value {fval.value} that does "
+                        f"Enum entry {fname} has value {fval} that does "
                         f"not conform to the expected Gray code value of {gray_val}"
                     )
+                assignments[fname] = fval
         # Determine width
-        if self._pt_width < 0:
-            self._pt_width = int(
-                math.ceil(math.log2(max(x.value for x in self._pt_fields.keys()) + 1))
+        if cls._PT_WIDTH < 0:
+            cls._PT_WIDTH = int(
+                math.ceil(math.log2(max(assignments.values()) + 1))
             )
         # Final checks
         used = []
-        max_val = (1 << self._pt_width) - 1
-        for fval, fname in self._pt_fields.items():
+        max_val = (1 << cls._PT_WIDTH) - 1
+        for fname, fval in assignments.items():
             # Check for oversized values
-            if fval.value > max_val:
+            if fval > max_val:
                 raise EnumError(
-                    f"Enum entry {fname} has value {fval.value} that cannot be "
-                    f"encoded in a bit width of {self._pt_width}"
+                    f"Enum entry {fname} has value {fval} that cannot be "
+                    f"encoded in a bit width of {cls._PT_WIDTH}"
                 )
             # Check for repeated values
-            if fval.value in used:
+            if fval in used:
                 raise EnumError(
-                    f"Enum entry {fname} has value {fval.value} that appears "
+                    f"Enum entry {fname} has value {fval} that appears "
                     f"more than once in the enumeration"
                 )
-            used.append(fval.value)
-            # Create a lookup table
-            self._pt_lookup[fval.value] = (fname, fval)
-        # Set initial value
-        self._pt_set(0)
+            used.append(fval)
+            # Create the enum instance
+            finst = cls(cls, fval)
+            setattr(cls, fname, finst)
+            cls._PT_LOOKUP[finst] = fname
+
+    @property
+    def _pt_width(self) -> int:
+        return self._PT_WIDTH
 
     @property
     def _pt_mask(self) -> int:
@@ -115,7 +134,7 @@ class Enum(Assembly):
         self._pt_set(value)
 
     def _pt_set(self, value: int, force: bool = False) -> None:
-        _, self.__value = self._pt_lookup.get(value, (None, int(value)))
+        _, self.__value = self._PT_LOOKUP.get(value, (None, int(value)))
         if not force:
             self._pt_updated()
 

--- a/packtype/enum.py
+++ b/packtype/enum.py
@@ -73,8 +73,7 @@ class Enum(Base):
                     fval = next_val
                 if (math.log2(fval) % 1) != 0:
                     raise EnumError(
-                        f"Enum entry {fname} has value {fval} that is not "
-                        f"one-hot"
+                        f"Enum entry {fname} has value {fval} that is not " f"one-hot"
                     )
                 next_val = fval << 1
                 assignments[fname] = fval
@@ -92,9 +91,7 @@ class Enum(Base):
                 assignments[fname] = fval
         # Determine width
         if cls._PT_WIDTH < 0:
-            cls._PT_WIDTH = int(
-                math.ceil(math.log2(max(assignments.values()) + 1))
-            )
+            cls._PT_WIDTH = int(math.ceil(math.log2(max(assignments.values()) + 1)))
         # Final checks
         used = []
         max_val = (1 << cls._PT_WIDTH) - 1

--- a/packtype/package.py
+++ b/packtype/package.py
@@ -29,54 +29,55 @@ from .wrap import get_wrapper
 
 
 class Package(Base):
-    _PT_SHARED: bool = True
+    _PT_FIELDS: dict
 
-    def __init__(self, parent: Base | None = None) -> None:
-        super().__init__(parent)
-        self._pt_fields = {}
-        for fname, ftype, fval in self._pt_definitions():
+    @classmethod
+    def _pt_construct(cls, parent: Base) -> None:
+        super()._pt_construct(parent)
+        cls._PT_FIELDS = {}
+        for fname, ftype, fval in cls._pt_definitions():
             if issubclass(ftype, Constant):
                 finst = ftype(default=fval)
-                setattr(self, fname, finst)
-                finst._PT_ATTACHED_TO = self
-                self._pt_fields[finst] = fname
+                setattr(cls, fname, finst)
+                finst._PT_ATTACHED_TO = cls
+                cls._PT_FIELDS[finst] = fname
             else:
-                setattr(self, fname, ftype)
-                ftype._PT_ATTACHED_TO = self
-                self._pt_fields[ftype] = fname
+                setattr(cls, fname, ftype)
+                ftype._PT_ATTACHED_TO = cls
+                cls._PT_FIELDS[ftype] = fname
 
-    def __call__(self) -> "Package":
-        return self
-
-    def enum(self, **kwds):
+    @classmethod
+    def enum(cls, **kwds):
         def _inner(ptcls: Any):
             enum = get_wrapper(Enum, frame_depth=2)(**kwds)(ptcls)
-            type(self)._PT_ATTACH.append(enum)
-            enum._PT_ATTACHED_TO = self
-            setattr(self, enum.__name__, enum)
-            self._pt_fields[enum] = enum.__name__
+            cls._PT_ATTACH.append(enum)
+            enum._PT_ATTACHED_TO = cls
+            setattr(cls, enum.__name__, enum)
+            cls._PT_FIELDS[enum] = enum.__name__
             return enum
 
         return _inner
 
-    def struct(self, **kwds):
+    @classmethod
+    def struct(cls, **kwds):
         def _inner(ptcls: Any):
             struct = get_wrapper(Struct, frame_depth=2)(**kwds)(ptcls)
-            type(self)._PT_ATTACH.append(struct)
-            struct._PT_ATTACHED_TO = self
-            setattr(self, struct.__name__, struct)
-            self._pt_fields[struct] = struct.__name__
+            cls._PT_ATTACH.append(struct)
+            struct._PT_ATTACHED_TO = cls
+            setattr(cls, struct.__name__, struct)
+            cls._PT_FIELDS[struct] = struct.__name__
             return struct
 
         return _inner
 
-    def union(self, **kwds):
+    @classmethod
+    def union(cls, **kwds):
         def _inner(ptcls: Any):
             union = get_wrapper(Union, frame_depth=2)(**kwds)(ptcls)
-            type(self)._PT_ATTACH.append(union)
-            union._PT_ATTACHED_TO = self
-            setattr(self, union.__name__, union)
-            self._pt_fields[union] = union.__name__
+            cls._PT_ATTACH.append(union)
+            union._PT_ATTACHED_TO = cls
+            setattr(cls, union.__name__, union)
+            cls._PT_FIELDS[union] = union.__name__
             return union
 
         return _inner
@@ -102,6 +103,10 @@ class Package(Base):
             )
 
         return set(filter(_is_a_type, foreign))
+
+    @property
+    def _pt_fields(self) -> dict:
+        return self._PT_FIELDS
 
     @property
     def _pt_constants(self) -> Iterable[Constant]:
@@ -141,5 +146,6 @@ class Package(Base):
             (x._pt_name(), x) for x in self._PT_ATTACH if issubclass(x, Struct | Union)
         )
 
-    def _pt_lookup(self, field: type[Base] | Base) -> str:
-        return self._pt_fields[field]
+    @classmethod
+    def _pt_lookup(cls, field: type[Base] | Base) -> str:
+        return cls._PT_FIELDS[field]

--- a/packtype/package.py
+++ b/packtype/package.py
@@ -34,7 +34,7 @@ class Package(Base):
     def __init__(self, parent: Base | None = None) -> None:
         super().__init__(parent)
         self._pt_fields = {}
-        for fname, ftype, fval in self._pt_definitions:
+        for fname, ftype, fval in self._pt_definitions():
             if issubclass(ftype, Constant):
                 finst = ftype(default=fval)
                 setattr(self, fname, finst)

--- a/packtype/primitive.py
+++ b/packtype/primitive.py
@@ -82,13 +82,14 @@ class Primitive(Base, metaclass=MetaPrimitive):
     def value(self, value: int) -> int:
         self._pt_set(value)
 
-    def _pt_set(self, value: int) -> int:
+    def _pt_set(self, value: int, force: bool = False) -> int:
         if value < 0 or (self._pt_width > 0 and value > self._pt_mask):
             raise PrimitiveValueError(
                 f"Value {value} cannot be represented by {self._pt_width} bits"
             )
-        self.__value = value
-        self._pt_updated()
+        self.__value = int(value)
+        if not force:
+            self._pt_updated()
 
     def __int__(self) -> int:
         return self.__value

--- a/packtype/primitive.py
+++ b/packtype/primitive.py
@@ -55,8 +55,8 @@ class Primitive(Base, metaclass=MetaPrimitive):
     _PT_WIDTH: int = -1
     _PT_SIGNED: bool = False
 
-    def __init__(self, parent: Base | None = None, default: int | None = None) -> None:
-        super().__init__(parent)
+    def __init__(self, default: int | None = None) -> None:
+        super().__init__()
         if type(self)._PT_ALLOW_DEFAULT:
             self.__value = None if default is None else int(default)
         else:

--- a/packtype/templates/package.sv.mako
+++ b/packtype/templates/package.sv.mako
@@ -69,9 +69,9 @@ typedef ${obj._PT_ALIAS._pt_name() | tc.snake_case}_t ${name | tc.snake_case}_t;
 // ${name}
 typedef enum logic [${width(obj)}:0] {
 <%  sep = " " %>\
-    %for field, fname in obj._pt_fields.items():
+    %for field, fname in obj._PT_LOOKUP.items():
 <%
-        prefix = tc.snake_case(obj._pt_prefix).upper()
+        prefix = tc.snake_case(obj._PT_PREFIX).upper()
         prefix += ["", "_"][len(prefix) > 0]
 %>\
     ${sep} ${prefix}${tc.snake_case(fname).upper()} = 'd${field.value}

--- a/packtype/templates/package.sv.mako
+++ b/packtype/templates/package.sv.mako
@@ -69,7 +69,7 @@ typedef ${obj._PT_ALIAS._pt_name() | tc.snake_case}_t ${name | tc.snake_case}_t;
 // ${name}
 typedef enum logic [${width(obj)}:0] {
 <%  sep = " " %>\
-    %for field, fname in obj._PT_LOOKUP.items():
+    %for field, fname in obj._PT_LKP_INST.items():
 <%
         prefix = tc.snake_case(obj._PT_PREFIX).upper()
         prefix += ["", "_"][len(prefix) > 0]
@@ -90,7 +90,7 @@ typedef enum logic [${width(obj)}:0] {
     %if isinstance(obj, Struct):
 typedef struct packed {
 <%
-        msb_pack = (obj._pt_packing == Packing.FROM_MSB)
+        msb_pack = (obj._PT_PACKING == Packing.FROM_MSB)
         next_pos = obj._pt_width - 1
         pad_idx  = 0
 %>\

--- a/packtype/union.py
+++ b/packtype/union.py
@@ -57,12 +57,15 @@ class Union(Assembly):
         inst._pt_set(packed)
         return inst
 
-    def _pt_set(self, value: int) -> None:
+    def _pt_set(self, value: int, force: bool = False) -> None:
         # Capture raw value
         self._pt_raw = value & self._pt_mask
         # Broadcast to all members
         for field in self._pt_fields.keys():
-            field._pt_set(self._pt_raw)
+            field._pt_set(self._pt_raw, force=True)
+        # Flag update
+        if not force:
+            self._pt_updated(self)
 
     def _pt_updated(self, obj: Base, *path: Base):
         # Block nested updates to avoid an infinite loop
@@ -74,7 +77,7 @@ class Union(Assembly):
         self._pt_raw = int(obj)
         for field in self._pt_fields.keys():
             if field is not obj:
-                field._pt_set(self._pt_raw)
+                field._pt_set(self._pt_raw, force=True)
         # Clear the lock
         self._pt_updating = False
         # Propagate update to the parent

--- a/packtype/union.py
+++ b/packtype/union.py
@@ -71,7 +71,7 @@ class Union(Assembly):
 
     def _pt_set(self, value: int, force: bool = False) -> None:
         # Capture raw value
-        self._pt_raw = value & self._pt_mask
+        self._pt_raw = int(value) & self._pt_mask
         # Broadcast to all members
         for field in self._pt_fields.keys():
             field._pt_set(self._pt_raw, force=True)

--- a/packtype/union.py
+++ b/packtype/union.py
@@ -21,18 +21,30 @@ class UnionError(Exception):
 
 
 class Union(Assembly):
-    def __init__(self, parent: Base | None = None) -> None:
-        self._pt_updating = True
-        super().__init__(parent)
-        self._pt_raw = 0
-        self._pt_width = next(iter(self._pt_fields.keys()))._pt_width
-        for field, fname in self._pt_fields.items():
-            if field._pt_width != self._pt_width:
-                raise UnionError(
-                    f"Union member {fname} has a width of {field._pt_width} that "
-                    f"differs from the expected width of {self._pt_width}"
-                )
+    _PT_WIDTH: int
+
+    def __init__(self, value: int = 0) -> None:
+        super().__init__()
         self._pt_updating = False
+        self._pt_set(value)
+
+    @classmethod
+    def _pt_construct(cls, parent: Base | None):
+        super()._pt_construct(parent)
+        cls._PT_WIDTH = None
+        for fname, ftype, _ in cls._pt_definitions():
+            fwidth = ftype()._pt_width
+            if cls._PT_WIDTH is None:
+                cls._PT_WIDTH = fwidth
+            elif fwidth != cls._PT_WIDTH:
+                raise UnionError(
+                    f"Union member {fname} has a width of {fwidth} that "
+                    f"differs from the expected width of {cls._PT_WIDTH}"
+                )
+
+    @property
+    def _pt_width(self) -> int:
+        return self._PT_WIDTH
 
     @property
     def _pt_mask(self) -> int:

--- a/packtype/wrap.py
+++ b/packtype/wrap.py
@@ -134,6 +134,8 @@ def get_wrapper(base: Any, frame_depth: int = 1) -> Callable:
             # Reattach functions
             for fname in cls_funcs:
                 setattr(imposter, fname, getattr(cls, fname))
+            # Imposter construction
+            imposter._pt_construct(**attrs)
             # If this is a 'shared' object then the imposter is replaced by an
             # instance rather than the definition
             if base._PT_SHARED:

--- a/packtype/wrap.py
+++ b/packtype/wrap.py
@@ -58,7 +58,7 @@ class Registry:
 
 @functools.cache
 def get_wrapper(base: Any, frame_depth: int = 1) -> Callable:
-    def _wrapper(**kwds) -> Callable:
+    def _wrapper(parent: Base | None = None, **kwds) -> Callable:
         def _inner(cls):
             # Work out the fields defined within the class
             cls_fields = set(dir(cls)).difference(dir(object))
@@ -98,10 +98,15 @@ def get_wrapper(base: Any, frame_depth: int = 1) -> Callable:
             # Check for supported attributes
             attrs = {}
             for key, value in kwds.items():
+                # Skip certain keys
+                if key in ("parent", ):
+                    continue
+                # Check if supported by the type
                 if key not in base._PT_ATTRIBUTES:
                     raise BadAttributeError(
                         f"Unsupported attribute '{key}' for {base.__name__}"
                     )
+                # Check value is acceptable
                 _, accepted = base._PT_ATTRIBUTES[key]
                 if (callable(accepted) and not accepted(value)) or (
                     isinstance(accepted, tuple) and value not in accepted
@@ -110,6 +115,7 @@ def get_wrapper(base: Any, frame_depth: int = 1) -> Callable:
                         f"Unsupported value '{value}' for attribute '{key}' "
                         f"for {base.__name__}"
                     )
+                # Store attribute
                 attrs[key] = value
             # Fill in default attributes
             for key, (default, _) in base._PT_ATTRIBUTES.items():
@@ -135,11 +141,7 @@ def get_wrapper(base: Any, frame_depth: int = 1) -> Callable:
             for fname in cls_funcs:
                 setattr(imposter, fname, getattr(cls, fname))
             # Imposter construction
-            imposter._pt_construct(**attrs)
-            # If this is a 'shared' object then the imposter is replaced by an
-            # instance rather than the definition
-            if base._PT_SHARED:
-                imposter = imposter()
+            imposter._pt_construct(parent, **attrs)
             # Register the imposter
             Registry.register(base, imposter)
             # Return the imposter as a substitute

--- a/tests/unit/test_enum.py
+++ b/tests/unit/test_enum.py
@@ -210,3 +210,20 @@ def test_enum_prefix():
         C: Constant
 
     assert TestEnum()._PT_PREFIX == "BLAH"
+
+
+def test_enum_casting():
+    @packtype.package()
+    class TestPkg:
+        pass
+
+    @TestPkg.enum()
+    class TestEnum:
+        A: Constant
+        B: Constant
+        C: Constant
+
+    assert TestEnum._pt_cast(0) is TestEnum.A
+    assert TestEnum._pt_cast(1) is TestEnum.B
+    assert TestEnum._pt_cast(2) is TestEnum.C
+    assert int(TestEnum._pt_cast(3)) == 3

--- a/tests/unit/test_enum.py
+++ b/tests/unit/test_enum.py
@@ -129,6 +129,7 @@ def test_enum_bad_one_hot():
         pass
 
     with pytest.raises(EnumError) as e:
+
         @TestPkg.enum(mode=EnumMode.ONE_HOT)
         class TestEnum:
             A: Constant = 1
@@ -144,6 +145,7 @@ def test_enum_bad_gray():
         pass
 
     with pytest.raises(EnumError) as e:
+
         @TestPkg.enum(mode=EnumMode.GRAY)
         class TestEnum:
             A: Constant = 0
@@ -163,6 +165,7 @@ def test_enum_bad_repeated():
         pass
 
     with pytest.raises(EnumError) as e:
+
         @TestPkg.enum(mode=EnumMode.INDEXED)
         class TestEnum:
             A: Constant = 0
@@ -181,6 +184,7 @@ def test_enum_bad_oversized():
         pass
 
     with pytest.raises(EnumError) as e:
+
         @TestPkg.enum(mode=EnumMode.INDEXED, width=2)
         class TestEnum:
             A: Constant

--- a/tests/unit/test_enum.py
+++ b/tests/unit/test_enum.py
@@ -33,10 +33,9 @@ def test_enum_auto_indexed():
         B: Constant
         C: Constant
 
-    inst = TestEnum()
-    assert int(inst.A) == 0
-    assert int(inst.B) == 1
-    assert int(inst.C) == 2
+    assert int(TestEnum.A) == 0
+    assert int(TestEnum.B) == 1
+    assert int(TestEnum.C) == 2
 
 
 def test_enum_auto_onehot():
@@ -50,10 +49,9 @@ def test_enum_auto_onehot():
         B: Constant
         C: Constant
 
-    inst = TestEnum()
-    assert int(inst.A) == 1
-    assert int(inst.B) == 2
-    assert int(inst.C) == 4
+    assert int(TestEnum.A) == 1
+    assert int(TestEnum.B) == 2
+    assert int(TestEnum.C) == 4
 
 
 def test_enum_auto_gray():
@@ -68,11 +66,10 @@ def test_enum_auto_gray():
         C: Constant
         D: Constant
 
-    inst = TestEnum()
-    assert int(inst.A) == 0
-    assert int(inst.B) == 1
-    assert int(inst.C) == 3
-    assert int(inst.D) == 2
+    assert int(TestEnum.A) == 0
+    assert int(TestEnum.B) == 1
+    assert int(TestEnum.C) == 3
+    assert int(TestEnum.D) == 2
 
 
 def test_enum_manual_indexed():
@@ -86,10 +83,9 @@ def test_enum_manual_indexed():
         B: Constant = 3
         C: Constant = 4
 
-    inst = TestEnum()
-    assert int(inst.A) == 2
-    assert int(inst.B) == 3
-    assert int(inst.C) == 4
+    assert int(TestEnum.A) == 2
+    assert int(TestEnum.B) == 3
+    assert int(TestEnum.C) == 4
 
 
 def test_enum_manual_onehot():
@@ -121,11 +117,10 @@ def test_enum_manual_gray():
         C: Constant = 3
         D: Constant = 2
 
-    inst = TestEnum()
-    assert int(inst.A) == 0
-    assert int(inst.B) == 1
-    assert int(inst.C) == 3
-    assert int(inst.D) == 2
+    assert int(TestEnum.A) == 0
+    assert int(TestEnum.B) == 1
+    assert int(TestEnum.C) == 3
+    assert int(TestEnum.D) == 2
 
 
 def test_enum_bad_one_hot():
@@ -133,14 +128,12 @@ def test_enum_bad_one_hot():
     class TestPkg:
         pass
 
-    @TestPkg.enum(mode=EnumMode.ONE_HOT)
-    class TestEnum:
-        A: Constant = 1
-        B: Constant = 2
-        C: Constant = 3
-
     with pytest.raises(EnumError) as e:
-        TestEnum()
+        @TestPkg.enum(mode=EnumMode.ONE_HOT)
+        class TestEnum:
+            A: Constant = 1
+            B: Constant = 2
+            C: Constant = 3
 
     assert str(e.value) == "Enum entry C has value 3 that is not one-hot"
 
@@ -150,15 +143,13 @@ def test_enum_bad_gray():
     class TestPkg:
         pass
 
-    @TestPkg.enum(mode=EnumMode.GRAY)
-    class TestEnum:
-        A: Constant = 0
-        B: Constant = 1
-        C: Constant = 2
-        D: Constant = 3
-
     with pytest.raises(EnumError) as e:
-        TestEnum()
+        @TestPkg.enum(mode=EnumMode.GRAY)
+        class TestEnum:
+            A: Constant = 0
+            B: Constant = 1
+            C: Constant = 2
+            D: Constant = 3
 
     assert str(e.value) == (
         "Enum entry C has value 2 that does not conform to the expected Gray "
@@ -171,15 +162,13 @@ def test_enum_bad_repeated():
     class TestPkg:
         pass
 
-    @TestPkg.enum(mode=EnumMode.INDEXED)
-    class TestEnum:
-        A: Constant = 0
-        B: Constant = 1
-        C: Constant = 2
-        D: Constant = 2
-
     with pytest.raises(EnumError) as e:
-        TestEnum()
+        @TestPkg.enum(mode=EnumMode.INDEXED)
+        class TestEnum:
+            A: Constant = 0
+            B: Constant = 1
+            C: Constant = 2
+            D: Constant = 2
 
     assert str(e.value) == (
         "Enum entry D has value 2 that appears more than once in the enumeration"
@@ -191,16 +180,14 @@ def test_enum_bad_oversized():
     class TestPkg:
         pass
 
-    @TestPkg.enum(mode=EnumMode.INDEXED, width=2)
-    class TestEnum:
-        A: Constant
-        B: Constant
-        C: Constant
-        D: Constant
-        E: Constant
-
     with pytest.raises(EnumError) as e:
-        TestEnum()
+        @TestPkg.enum(mode=EnumMode.INDEXED, width=2)
+        class TestEnum:
+            A: Constant
+            B: Constant
+            C: Constant
+            D: Constant
+            E: Constant
 
     assert str(e.value) == (
         "Enum entry E has value 4 that cannot be encoded in a bit width of 2"
@@ -218,4 +205,4 @@ def test_enum_prefix():
         B: Constant
         C: Constant
 
-    assert TestEnum()._pt_prefix == "BLAH"
+    assert TestEnum()._PT_PREFIX == "BLAH"

--- a/tests/unit/test_package.py
+++ b/tests/unit/test_package.py
@@ -28,7 +28,7 @@ def test_package_decl():
     class TestPkg:
         pass
 
-    assert isinstance(TestPkg, Package)
+    assert issubclass(TestPkg, Package)
 
 
 def test_package_constants():

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -15,7 +15,7 @@
 import pytest
 import packtype
 from packtype import Constant, Packing, Scalar
-from packtype.assembly import WidthError
+from packtype.assembly import WidthError, AssignmentError
 from packtype.primitive import PrimitiveValueError
 from packtype.wrap import BadAssignmentError, BadAttributeError
 
@@ -131,14 +131,12 @@ def test_struct_oversized():
     class TestPkg:
         pass
 
-    @TestPkg.struct(width=17)
-    class TestStruct:
-        ab: Scalar[12]
-        cd: Scalar[3]
-        ef: Scalar[9]
-
     with pytest.raises(WidthError) as e:
-        TestStruct()
+        @TestPkg.struct(width=17)
+        class TestStruct:
+            ab: Scalar[12]
+            cd: Scalar[3]
+            ef: Scalar[9]
 
     assert str(e.value) == (
         "Fields of TestStruct total 24 bits which does not fit within the "
@@ -305,3 +303,58 @@ def test_struct_enum():
     assert int(inst.a) == 2
     assert int(inst.b) == 0x1234
     assert int(inst.c) == 7
+
+
+def test_struct_constructor():
+    @packtype.package()
+    class TestPkg:
+        pass
+
+    @TestPkg.struct()
+    class TestStruct:
+        ab: Scalar[12]
+        cd: 3 * Scalar[3]
+        ef: Scalar[9]
+
+    inst = TestStruct(ab=123, cd=[4, 5, 6], ef=41)
+    assert int(inst.ab) == 123
+    assert int(inst.cd[0]) == 4
+    assert int(inst.cd[1]) == 5
+    assert int(inst.cd[2]) == 6
+    assert int(inst.ef) == 41
+
+
+def test_struct_bad_constructor():
+    @packtype.package()
+    class TestPkg:
+        pass
+
+    @TestPkg.struct()
+    class TestStruct:
+        ab: Scalar[12]
+        cd: 3 * Scalar[3]
+        ef: Scalar[9]
+
+    # Test a single value being assigned to an array
+    with pytest.raises(AssignmentError) as e:
+        TestStruct(ab=123, cd=4, ef=41)
+
+    assert str(e.value) == (
+        "Cannot assign value to field cd as it is an array of 3 entries and the "
+        "assigned value does not have the same dimensions"
+    )
+
+    # Test assigning an array that's too small
+    with pytest.raises(AssignmentError) as e:
+        TestStruct(ab=123, cd=[4, 5], ef=41)
+
+    assert str(e.value) == (
+        "Cannot assign value to field cd as it is an array of 3 entries and the "
+        "assigned value does not have the same dimensions"
+    )
+
+    # Check that extra field is flagged
+    with pytest.raises(AssignmentError) as e:
+        TestStruct(ab=123, cd=[4, 5, 6], ef=41, gh=3)
+
+    assert str(e.value) == "TestStruct does not contain a field called 'gh'"

--- a/tests/unit/test_union.py
+++ b/tests/unit/test_union.py
@@ -14,7 +14,7 @@
 
 import pytest
 import packtype
-from packtype import Scalar
+from packtype import Constant, Scalar
 from packtype.union import UnionError
 
 from ..fixtures import reset_registry
@@ -49,10 +49,26 @@ def test_union_nested():
     class TestPkg:
         pass
 
+    @TestPkg.enum(width=3)
+    class EnumA:
+        A: Constant
+        B: Constant
+        C: Constant
+
+    @TestPkg.struct()
+    class StructA:
+        a: Scalar[10]
+        b: EnumA
+
+    @TestPkg.struct(width=13)
+    class StructB:
+        a: Scalar[5]
+        # Deliberately missing to force padding
+
     @TestPkg.union()
     class UnionA:
-        a: Scalar[13]
-        b: Scalar[13]
+        a: StructA
+        b: StructB
         c: Scalar[13]
 
     @TestPkg.union()
@@ -60,12 +76,24 @@ def test_union_nested():
         a: UnionA
         b: Scalar[13]
 
+    # Packing
     inst = UnionB()
     inst.a.b = 142
     assert int(inst.a.a) == 142
     assert int(inst.a.b) == 142
     assert int(inst.a.c) == 142
     assert int(inst.b) == 142
+    assert inst._pt_pack() == 142
+
+    # Unpacking
+    inst = UnionB._pt_unpack(142)
+    assert int(inst.a.a) == 142
+    assert int(inst.a.b) == 142
+    assert int(inst.a.c) == 142
+    assert int(inst.b) == 142
+
+    # Repacking
+    assert inst.a._pt_pack() == 142
 
 
 def test_union_struct():

--- a/tests/unit/test_union.py
+++ b/tests/unit/test_union.py
@@ -155,13 +155,11 @@ def test_union_bad_widths():
     class TestPkg:
         pass
 
-    @TestPkg.union()
-    class TestUnion:
-        a: Scalar[12]
-        b: Scalar[11]
-
     with pytest.raises(UnionError) as e:
-        TestUnion()
+        @TestPkg.union()
+        class TestUnion:
+            a: Scalar[12]
+            b: Scalar[11]
 
     assert str(e.value) == (
         "Union member b has a width of 11 that differs from the expected width " "of 12"


### PR DESCRIPTION
 * Adding `_pt_construct` method that is called by the wrapper builder allowing for class-specific construction;
 * Removing `_PT_SHARED` and instead attaching fields to package in `_pt_construct`;
 * Allowing `Struct` definitions to be created with named field assignments through `__init__`;
 * Adding `_pt_cast` to `Enum` to allow for known values to be retrieved;
 * Adding explicit casts in `_pt_set` to allow int-like types to be used in assignments;
 * Fixing issue with union assignment recursion