### PR TITLE
Performance improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,3 +221,21 @@ class MessageBus:
     header    : MessageHeader
     ping_pong : PingPongPayload
 ```
+
+### Profiling
+
+Using Packtype objects within a testbench can cause significant overhead if many
+pack and unpack operations are being performed. To help diagnose performance
+issues, you can enable profiling which counts the number of each type of object
+that are created during a run:
+
+```python
+from packtype.base import Base
+
+def my_test_function():
+    Base._pt_enable_profiling(limit=10)
+```
+
+The `limit` keyword will filter out any objects from the report that have less
+than this number of creations by the end of the run, this can be useful to
+filter out noise of many small unique objects.

--- a/examples/tests.sh
+++ b/examples/tests.sh
@@ -20,7 +20,7 @@ this_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Create a virtual environment
 python3 -m virtualenv ${this_dir}/venv
 source ${this_dir}/venv/bin/activate
-python3 ${this_dir}/../setup.py develop
+python3 -m pip install ${this_dir}/..
 
 # Run all tests in subdirectories
 passed=0

--- a/packtype/bitvector.py
+++ b/packtype/bitvector.py
@@ -1,0 +1,162 @@
+# Copyright 2023, Peter Birch, mailto:peter@intuity.io
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from math import ceil, log2
+
+class BitVector:
+    """
+    Bit vector acts as the storage mechanism that backs Packtype structs, unions,
+    and other types allowing for different projections of the same bits to be
+    made in an efficient manner.
+
+    :param width: Width of the bit vector
+    :param value: Initial value for the bit vector, defaults to 0
+    """
+
+    def __init__(self, width: int | None = None, value: int = 0) -> None:
+        self.__width = width
+        self.__value = 0
+
+    @property
+    def width(self) -> int:
+        """ Return the bit vector width """
+        return self.__width
+
+    @property
+    def value(self) -> int:
+        """ Return the bit vector value """
+        return self.__value
+
+    def __int__(self) -> int:
+        return self.__value
+
+    @functools.lru_cache()
+    def create_window(self, msb: int, lsb: int) -> "BitVectorWindow":
+        """
+        Create a window into a section of the bit vector that can be used to
+        either project a value from a wider range or update a specific part of
+        the full bit vector.
+
+        :param msb: MSB of the window
+        :param lsb: LSB of the window
+        :returns:   A BitVectorWindow matching the request
+        """
+        assert self.__width is None or msb < self.__width, (
+            f"MSB of {msb} exceeds width {self.__width}"
+        )
+        assert lsb >= 0, f"LSB of {lsb} is not supported"
+        return BitVectorWindow(self, msb, lsb)
+
+    def extract(self, msb: int, lsb: int) -> int:
+        """
+        Extract a specific window of the bit vector.
+
+        :param msb: MSB of the window
+        :param lsb: LSB of the window
+        :returns:   Value extracted from the window
+        """
+        return (self.__value >> lsb) & ((1 << (msb - lsb + 1)) - 1)
+
+    def set(self, value: int, msb: int | None = None, lsb: int | None = None) -> None:
+        """
+        Set the value of a specific window of the bit vector.
+
+        :param value: Value to set
+        :param msb:   MSB of the window, defaults to width - 1
+        :param lsb:   LSB of the window, defaults to 0
+        """
+        # Coerce the value to an integer
+        value = int(value)
+        # If no MSB/LSB provided, overwrite the entire value
+        if msb is None and lsb is None:
+            self.__value = value
+        # Otherwise mask and insert the value
+        else:
+            # If width is not set, attempt to infer it
+            width = self.__width
+            if width is None:
+                width = int(ceil(log2(max(value, self.__value))))
+            # Default LSB/MSB
+            lsb = lsb if lsb is not None else 0
+            msb = msb if msb is not None else (width - 1)
+            # Sanity chedck arguments
+            assert msb < width, f"MSB of {msb} exceeds width {width}"
+            assert lsb >= 0, f"LSB of {lsb} is not supported"
+            # Update value with masking
+            mask = ((1 << (msb - lsb + 1)) - 1) << lsb
+            inv_mask = ((1 << width) - 1) ^ mask
+            self.__value = (self.__value & inv_mask) | ((value << lsb) & mask)
+
+
+class BitVectorWindow:
+    """
+    Supports easy access to a specific range of a wider BitVector, allowing the
+    value of the range to be read or written.
+
+    :param bitvector: Points at the parent BitVector
+    :param msb:       MSB of the window
+    :param lsb:       LSB of the window
+    """
+
+    def __init__(self, bitvector: BitVector, msb: int, lsb: int) -> None:
+        self.__bitvector = bitvector
+        self.__msb = msb
+        self.__lsb = lsb
+
+    @property
+    def msb(self) -> int:
+        """ Return the window's MSB """
+        return self.__msb
+
+    @property
+    def lsb(self) -> int:
+        """ Return the window's LSB """
+        return self.__lsb
+
+    @property
+    def width(self) -> int:
+        """ Return the window's width """
+        return (self.__msb - self.__lsb) + 1
+
+    def __int__(self) -> int:
+        """ Cast the window to an int by extracting the right bit range """
+        return self.__bitvector.extract(self.__msb, self.__lsb)
+
+    def create_window(self, msb: int, lsb: int) -> "BitVectorWindow":
+        """
+        Derive a new window within this one, testing that the requested MSB/LSB
+        do not exceed the bounds.
+
+        :param msb: MSB of the new window (relative to this window's LSB)
+        :param lsb: LSB of the new window (relative to this window's LSB)
+        :returns:   The new window
+        """
+        assert lsb >= 0, f"LSB of {lsb} is not supported"
+        assert msb < self.width, f"MSB of {msb} is not supported"
+        return self.__bitvector.create_window(msb+self.__lsb, lsb+self.__lsb)
+
+    def set(self, value: int, msb: int | None = None, lsb: int | None = None) -> None:
+        """
+        Set the value of a specific sub-window of this bit vector window.
+
+        :param value: Value to set
+        :param msb:   MSB of the sub-window, defaults to width - 1
+        :param lsb:   LSB of the sub-window, defaults to 0
+        """
+        msb = (self.width - 1) if msb is None else msb
+        lsb = 0 if lsb is None else lsb
+        assert lsb >= 0, f"LSB of {lsb} is not supported"
+        assert msb < self.width, f"MSB of {msb} is not supported"
+        return self.__bitvector.set(value, msb+self.__lsb, lsb+self.__lsb)

--- a/packtype/packing.py
+++ b/packtype/packing.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .primitive import Primitive
+from enum import Enum, auto
 
 
-class Scalar(Primitive):
-    pass
+class Packing(Enum):
+    FROM_LSB = auto()
+    FROM_MSB = auto()

--- a/packtype/primitive.py
+++ b/packtype/primitive.py
@@ -20,6 +20,7 @@ except ImportError:
     from typing_extensions import Self  # noqa: UP035
 
 from .base import Base, MetaBase
+from .bitvector import BitVector, BitVectorWindow
 from .numeric import Numeric
 
 
@@ -56,12 +57,12 @@ class Primitive(Base, Numeric, metaclass=MetaPrimitive):
     _PT_WIDTH: int = -1
     _PT_SIGNED: bool = False
 
-    def __init__(self, default: int | None = None) -> None:
-        super().__init__()
+    def __init__(self,
+                 default: int | None = None,
+                 _pt_bv: BitVector | BitVectorWindow | None = None) -> None:
+        super().__init__(_pt_bv=_pt_bv)
         if type(self)._PT_ALLOW_DEFAULT:
-            self.__value = None if default is None else int(default)
-        else:
-            self.__value = 0
+            self._pt_bv.set(0 if default is None else int(default))
 
     @property
     def _pt_width(self) -> int:
@@ -77,21 +78,19 @@ class Primitive(Base, Numeric, metaclass=MetaPrimitive):
 
     @property
     def value(self) -> int:
-        return self.__value
+        return int(self._pt_bv)
 
     @value.setter
     def value(self, value: int) -> int:
         self._pt_set(value)
 
-    def _pt_set(self, value: int, force: bool = False) -> int:
+    def _pt_set(self, value: int) -> int:
         value = int(value)
         if value < 0 or (self._pt_width > 0 and value > self._pt_mask):
             raise PrimitiveValueError(
                 f"Value {value} cannot be represented by {self._pt_width} bits"
             )
-        self.__value = value
-        if not force:
-            self._pt_updated()
+        self._pt_bv.set(value)
 
     def __int__(self) -> int:
-        return self.__value
+        return int(self._pt_bv)

--- a/tests/unit/test_struct.py
+++ b/tests/unit/test_struct.py
@@ -357,4 +357,4 @@ def test_struct_bad_constructor():
     with pytest.raises(AssignmentError) as e:
         TestStruct(ab=123, cd=[4, 5, 6], ef=41, gh=3)
 
-    assert str(e.value) == "TestStruct does not contain a field called 'gh'"
+    assert str(e.value) == "TestStruct does not contain fields called 'gh'"

--- a/tests/unit/test_union.py
+++ b/tests/unit/test_union.py
@@ -166,27 +166,6 @@ def test_union_bad_widths():
     )
 
 
-def test_union_mismatches():
-    @packtype.package()
-    class TestPkg:
-        pass
-
-    @TestPkg.union()
-    class TestUnion:
-        a: Scalar[12]
-        b: Scalar[12]
-
-    with pytest.raises(UnionError) as e:
-        inst = TestUnion._pt_unpack(0x23)
-        inst.a._Primitive__value = 0x17
-        inst._pt_pack()
-
-    assert str(e.value) == (
-        "Multiple member values were discovered when packing a TestUnion union "
-        "- expected a value of 0x23 but saw 0x23, 0x17"
-    )
-
-
 def test_union_functions():
     @packtype.package()
     class TestPkg:


### PR DESCRIPTION
Through profiling it was confirmed that the way unions were implemented (by broadcasting changes through `_pt_updated`) was very inefficient. This PR moves to backing all Packtype objects with a `BitVector` object that handles the data storage and bit extraction/alteration.

In simulations a 10x speedup was achieved from these changes.

This work also introduces a `Base._pt_enable_profiling()` method that prints out a report of the number of objects created at the end of the run, this can be helpful when debugging performance issues.