### PR TITLE
Making aliases unique

### DIFF
--- a/packtype/alias.py
+++ b/packtype/alias.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import functools
+from collections import defaultdict
 
 from .base import Base, MetaBase
 
 
 class MetaAlias(MetaBase):
+    UNIQUE_ID: dict[str, int] = defaultdict(lambda: 0)
+
     def __call__(self, *args, **kwds):
         return self._PT_ALIAS(*args, **kwds)
 
@@ -25,11 +27,17 @@ class MetaAlias(MetaBase):
         assert issubclass(to_alias, Base), "Can only alias a Packtype type"
         return MetaAlias.get_variant(self, to_alias)
 
-    @functools.lru_cache
     @staticmethod
     def get_variant(alias: "Alias", to_alias: Base):
+        # NOTE: Don't share aliases between creations as this prevents the
+        #       parent being distinctly tracked (a problem when they are used as
+        #       typedefs on a package)
+        uid = MetaAlias.UNIQUE_ID[alias.__name__]
+        MetaAlias.UNIQUE_ID[alias.__name__] += 1
         return type(
-            alias.__name__ + f"_{to_alias.__name__}", (alias,), {"_PT_ALIAS": to_alias}
+            alias.__name__ + f"_{to_alias.__name__}_{uid}",
+            (alias,),
+            {"_PT_ALIAS": to_alias}
         )
 
 


### PR DESCRIPTION
Fixes an issue where if two aliases are derived from the same type in a package, only one will be rendered due to the unique dictionary key.