### PR TITLE
Fix issue with double underscore

### DIFF
--- a/packtype/templates/common.py
+++ b/packtype/templates/common.py
@@ -24,7 +24,7 @@ def snake_case(raw: str) -> str:
     :returns:   A snake_case string
     """
     parts = filter(lambda x: len(x) > 0, RGX_CAMEL.split(raw))
-    return "_".join(x.lower() for x in parts)
+    return "_".join(x.lower().strip("_") for x in parts)
 
 
 def shouty_snake_case(raw: str) -> str:


### PR DESCRIPTION
Fix an odd behaviour where an underscore could end up duplicated if the input string takes the form `X_Y1` producing `X__Y1` where it should produce `X_Y1`