### PR TITLE
Small improvements

### DIFF
--- a/docs/utilities/constant.md
+++ b/docs/utilities/constant.md
@@ -1,0 +1,5 @@
+::: packtype.utils.constant
+    options:
+      show_root_heading: true
+      heading_level: 2
+      show_source: false

--- a/examples/structs/spec.pt
+++ b/examples/structs/spec.pt
@@ -4,10 +4,15 @@
 
 package calendar {
 
+    DAY_WIDTH : constant = 5
+    MONTH_WIDTH : constant = 4
+    YEAR_WIDTH : constant = 12
+    DATE_WIDTH : constant = DAY_WIDTH + MONTH_WIDTH + YEAR_WIDTH
+
     struct date_t {
-        day   : scalar[5]
-        month : scalar[4]
-        year  : scalar[12]
+        day   : scalar[DAY_WIDTH]
+        month : scalar[MONTH_WIDTH]
+        year  : scalar[YEAR_WIDTH]
     }
 
     struct msb [17] time_t {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
     - Unions: syntax/union.md
   - Utilities:
     - Basic: utilities/basic.md
+    - Constants: utilities/constant.md
     - Enums: utilities/enum.md
     - Structs: utilities/struct.md
     - Unions: utilities/union.md

--- a/packtype/grammar/declarations.py
+++ b/packtype/grammar/declarations.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 
-from ..grammar.expression import DeclExpr
+from ..common.expression import Expression
 from ..types.alias import Alias
 from ..types.assembly import Packing
 from ..types.base import Base
@@ -78,8 +78,8 @@ class DeclAlias:
 class DeclConstant:
     position: Position
     name: str
-    width: DeclExpr
-    expr: DeclExpr
+    width: Expression
+    expr: Expression
     description: Description | None = None
 
     def to_instance(
@@ -93,7 +93,7 @@ class DeclConstant:
     ) -> Constant:
         # Resolve width
         width = self.width
-        if isinstance(width, DeclExpr):
+        if isinstance(width, Expression):
             width = width.evaluate(cb_resolve)
         # Evaluate the expression referring to known constants
         value = self.expr.evaluate(cb_resolve)
@@ -112,7 +112,7 @@ class DeclScalar:
     position: Position
     name: str
     signedness: type[Signed | Unsigned]
-    width: DeclExpr
+    width: Expression
     description: Description | None = None
 
     def resolve_width(
@@ -124,7 +124,7 @@ class DeclScalar:
             int | type[Base],
         ],
     ) -> int:
-        if isinstance(self.width, DeclExpr):
+        if isinstance(self.width, Expression):
             return self.width.evaluate(cb_resolve)
         elif self.width is None:
             return 1
@@ -167,7 +167,7 @@ class DeclEnum:
     position: Position
     name: str
     mode: EnumMode
-    width: DeclExpr | None
+    width: Expression | None
     description: Description | None
     modifiers: list[Modifier] | None
     values: list
@@ -187,7 +187,7 @@ class DeclEnum:
     ) -> type[Enum]:
         # Resolve width
         width = self.width
-        if isinstance(width, DeclExpr):
+        if isinstance(width, Expression):
             width = width.evaluate(cb_resolve)
         # Process entries
         entries = {}
@@ -227,7 +227,7 @@ class DeclStruct:
     position: Position
     name: str
     packing: Packing
-    width: DeclExpr | None
+    width: Expression | None
     description: Description | None
     modifiers: list[Modifier] | None
     fields: list[str]
@@ -247,7 +247,7 @@ class DeclStruct:
     ) -> type[Struct]:
         # Resolve width
         width = self.width
-        if isinstance(width, DeclExpr):
+        if isinstance(width, Expression):
             width = width.evaluate(cb_resolve)
         # Process entries
         fields = {}

--- a/packtype/grammar/grammar.py
+++ b/packtype/grammar/grammar.py
@@ -177,6 +177,19 @@ def parse_string(
             case _:
                 raise Exception(f"Unhandled declaration: {decl}")
 
+    # Check for overrides that don't match up
+    for name in constant_overrides.keys():
+        if not hasattr(package, name):
+            raise UnknownEntityError(
+                f"Constant override '{name}' does not match any defined constant "
+                f"in package '{package.__name__}'"
+            )
+        elif not isinstance(getattr(package, name), Constant):
+            raise TypeError(
+                f"Constant override '{name}' does not match a constant in package "
+                f"'{package.__name__}', found {getattr(package, name).__name__}"
+            )
+
     return package
 
 

--- a/packtype/grammar/grammar.py
+++ b/packtype/grammar/grammar.py
@@ -61,17 +61,20 @@ def parse_string(
     namespaces: dict[str, Package] | None = None,
     constant_overrides: dict[str, int] | None = None,
     source: Path | None = None,
+    keep_expression: bool = False,
 ) -> Package:
     """
     Parse a Packtype definition from a string producing a Package object.
 
     :param definition:         The Packtype definition as a string.
     :param namespaces:         A dictionary of known packages to resolve imports.
-    :param source:             An optional source path for error reporting and
-                               associating each declaration with its source file.
     :param constant_overrides: Optional overrides for constants defined within
                                the package, where the key must precisely match
                                the constant's name
+    :param source:             An optional source path for error reporting and
+                               associating each declaration with its source file.
+    :param keep_expression:    If True, expressions will be attached to constants
+                               allowing them to be re-evaluated with new inputs.
     :return:                   A Package object representing the parsed definition.
     """
     # If no namespaces are provided, use an empty dict
@@ -145,7 +148,10 @@ def parse_string(
                 known_entities[decl.name] = (scalar, decl.position)
             # Build constants
             case DeclConstant():
-                package._pt_attach_constant(decl.name, constant := decl.to_instance(_resolve))
+                constant = decl.to_instance(_resolve)
+                if keep_expression:
+                    constant._PT_EXPRESSION = decl.expr
+                package._pt_attach_constant(decl.name, constant)
                 # Check for name collisions
                 _check_collision(decl.name)
                 # Check for a constant override
@@ -197,6 +203,7 @@ def parse(
     path: Path,
     namespaces: dict[str, Package] | None = None,
     constant_overrides: dict[str, int] | None = None,
+    keep_expression: bool = False,
 ) -> Package:
     """
     Parse a Packtype definition from a file path producing a Package object.
@@ -206,7 +213,15 @@ def parse(
     :param constant_overrides: Optional overrides for constants defined within
                                the package, where the key must precisely match
                                the constant's name.
+    :param keep_expression:    If True, expressions will be attached to constants
+                               allowing them to be re-evaluated with new inputs.
     :return:                   A Package object representing the parsed definition.
     """
     with path.open("r", encoding="utf-8") as fh:
-        return parse_string(fh.read(), namespaces, constant_overrides, path)
+        return parse_string(
+            definition=fh.read(),
+            namespaces=namespaces,
+            constant_overrides=constant_overrides,
+            source=path,
+            keep_expression=keep_expression,
+        )

--- a/packtype/grammar/transformer.py
+++ b/packtype/grammar/transformer.py
@@ -25,7 +25,7 @@ from .declarations import (
     Signed,
     Unsigned,
 )
-from .expression import DeclExpr, DeclExprFunction
+from ..common.expression import Expression, ExpressionFunction
 
 
 class PacktypeTransformer(Transformer):
@@ -50,10 +50,10 @@ class PacktypeTransformer(Transformer):
                 method_func = utils.get_width
             case _:
                 method_func = getattr(math, method, None)
-        return DeclExprFunction(method_func, *args)
+        return ExpressionFunction(method_func, *args)
 
     def expr(self, body):
-        return DeclExpr.digest(body)
+        return Expression.digest(body)
 
     def signed(self, *_):
         return Signed
@@ -100,8 +100,8 @@ class PacktypeTransformer(Transformer):
         # Extract optional width and constant value
         if (
             len(remainder) >= 2
-            and isinstance(remainder[0], DeclExpr)
-            and isinstance(remainder[1], DeclExpr)
+            and isinstance(remainder[0], Expression)
+            and isinstance(remainder[1], Expression)
         ):
             width, expr, *remainder = remainder
         else:
@@ -134,7 +134,7 @@ class PacktypeTransformer(Transformer):
         else:
             mode = EnumMode.INDEXED
         # Pickup width if given
-        if remainder and isinstance(remainder[0], DeclExpr):
+        if remainder and isinstance(remainder[0], Expression):
             width, *remainder = remainder
         else:
             width = None
@@ -168,10 +168,10 @@ class PacktypeTransformer(Transformer):
         else:
             signed = Unsigned
         # Pickup width
-        if remainder and isinstance(remainder[0], DeclExpr):
+        if remainder and isinstance(remainder[0], Expression):
             width, *remainder = remainder
         else:
-            width = DeclExpr(1)
+            width = Expression(1)
         # Pickup description
         if remainder and isinstance(remainder[0], Description):
             descr = remainder[0]
@@ -188,7 +188,7 @@ class PacktypeTransformer(Transformer):
         else:
             packing = Packing.FROM_LSB
         # Extract width if given
-        if isinstance(remainder[0], DeclExpr):
+        if isinstance(remainder[0], Expression):
             width, name, *remainder = remainder
         else:
             width = None

--- a/packtype/types/constant.py
+++ b/packtype/types/constant.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from ..common.expression import Expression
 from .primitive import NumericPrimitive
 
 
 class Constant(NumericPrimitive):
-    pass
+    _PT_EXPRESSION: Expression | None = None

--- a/packtype/types/numeric.py
+++ b/packtype/types/numeric.py
@@ -144,6 +144,9 @@ class Numeric:
     def __abs__(self) -> int:
         return abs(int(self))
 
+    def __index__(self) -> int:
+        return int(self._pt_bv)
+
     def __invert__(self) -> int:
         return ~int(self)
 

--- a/packtype/types/primitive.py
+++ b/packtype/types/primitive.py
@@ -97,3 +97,6 @@ class NumericPrimitive(Base, Numeric, metaclass=MetaPrimitive):
 
     def __int__(self) -> int:
         return int(self._pt_bv)
+
+    def __float__(self) -> float:
+        return float(int(self))

--- a/packtype/utils/__init__.py
+++ b/packtype/utils/__init__.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from . import enum, package, struct, union
+from . import constant, enum, package, struct, union
 from .basic import clog2, get_doc, get_name, get_source, get_width, is_signed
 
 __all__ = [
     "clog2",
+    "constant",
     "enum",
     "get_doc",
     "get_name",

--- a/packtype/utils/constant.py
+++ b/packtype/utils/constant.py
@@ -1,0 +1,11 @@
+# Copyright 2023-2025, Peter Birch, mailto:peter@intuity.io
+# SPDX-License-Identifier: Apache-2.0
+#
+
+from ..common.expression import Expression
+from ..types.constant import Constant
+
+
+def get_expression(constant: Constant) -> Expression | None:
+    """Get the expression associated with a constant."""
+    return constant._PT_EXPRESSION

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "packtype"
-version = "3.0.0"
+version = "3.0.1"
 description = "Packed data structure specifications for multi-language hardware projects"
 authors = ["Peter Birch <peter@intuity.io>"]
 license = "Apache-2.0"

--- a/tests/grammar/test_constant.py
+++ b/tests/grammar/test_constant.py
@@ -93,6 +93,42 @@ def test_parse_constant_override():
     assert pkg.C.value == 123 + 456
 
 
+def test_parse_constant_override_unknown():
+    """Test parsing a constant override that does not match any defined constant."""
+    with pytest.raises(
+        UnknownEntityError,
+        match="Constant override 'UNKNOWN' does not match any defined constant",
+    ):
+        parse_string(
+            """
+            package the_package {
+                A: constant = 42
+            }
+            """,
+            constant_overrides={"UNKNOWN": 123},
+        )
+
+
+def test_parse_constant_override_type_mismatch():
+    """Test parsing a constant override that does not match a defined constant."""
+    with pytest.raises(
+        TypeError,
+        match=(
+            "Constant override 'b' does not match a constant in package "
+            "'the_package', found Scalar_42U_0"
+        )
+    ):
+        parse_string(
+            """
+            package the_package {
+                A: constant = 42
+                b: scalar[A]
+            }
+            """,
+            constant_overrides={"b": 123},
+        )
+
+
 def test_parse_constant_no_value():
     """Test parsing a constant definition without a value."""
     with pytest.raises(ParseError, match="Failed to parse input"):

--- a/tests/grammar/test_constant.py
+++ b/tests/grammar/test_constant.py
@@ -45,6 +45,34 @@ def test_parse_constant():
     assert pkg.C.__doc__ == "Declarations are case insensitive"
 
 
+def test_parse_constant_keep_expression():
+    """Test keeping the expression when parsing a constant definition"""
+    # Not kept
+    pkg = parse_string(
+        """
+        package the_package {
+            A: constant = 1
+            B: constant = 2
+            C: constant = A + B
+        }
+        """
+    )()
+    assert pkg.C._PT_EXPRESSION is None
+    # Kept
+    pkg = parse_string(
+        """
+        package the_package {
+            A: constant = 1
+            B: constant = 2
+            C: constant = A + B
+        }
+        """,
+        keep_expression=True,
+    )()
+    assert pkg.C._PT_EXPRESSION is not None
+    assert pkg.C._PT_EXPRESSION.evaluate({ "A": 4, "B": 5 }.get) == 4 + 5
+
+
 def test_parse_constant_override():
     """Test parsing a constant definition within a package"""
     # Parse without overrides

--- a/tests/pysyntax/test_constant.py
+++ b/tests/pysyntax/test_constant.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import math
+
 import packtype
 from packtype import Constant
 
@@ -112,6 +114,15 @@ def test_constant_arithmetic():
     assert (TestPkg.A != TestPkg.B) == (35 != 17)
     assert (TestPkg.A > TestPkg.B) == (35 > 17)
     assert (TestPkg.A >= TestPkg.B) == (35 >= 17)
+
+    # Check that math functions work without casting
+    math.log2(TestPkg.A) == math.log2(35)
+
+    # For that the value can be used as an index
+    expected = 0
+    for idx in range(TestPkg.A):
+        assert idx == expected
+        expected += 1
 
 
 def test_constant_reference():

--- a/tests/utils/test_utils_constant.py
+++ b/tests/utils/test_utils_constant.py
@@ -1,0 +1,28 @@
+# Copyright 2023-2025, Peter Birch, mailto:peter@intuity.io
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import packtype
+from packtype import Constant, utils
+from packtype.grammar.grammar import parse_string
+
+from ..fixtures import reset_registry
+
+assert reset_registry
+
+
+def test_utils_enum_get_entries():
+    PackageA = parse_string(
+        """
+        package PackageA {
+            A: constant = 1
+            B: constant = 2
+            C: constant = A + B
+        }
+        """,
+        keep_expression=True,
+    )
+    assert utils.constant.get_expression(PackageA.C) is not None
+    assert utils.constant.get_expression(PackageA.C).evaluate(
+        {"A": 3, "B": 4}.get
+    ) == 3 + 4


### PR DESCRIPTION
A number of small improvements:
 * Flags unused or invalid constant overrides when parsing packtype grammar
 * Constant expressions can be optionally attached as `_PT_EXPRESSION` if `keep_expression=True` when using packtype grammar (`utils.constant.get_expression()` can be used to retrieve this)
 * Addition of `__float__` and `__index__` methods to `NumericPrimitive` to reduce the need for explicit `int(...)` casts in many places